### PR TITLE
Used py3 compatible print

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import setup, find_packages
 
 
 install_requires = ['redis']
-print find_packages()
+sys.stdout.write("%s\n" % find_packages())
 
 setup(
     name='twiceredis',


### PR DESCRIPTION
quark is attempting to pass py3 UT and needs twice redis to successfully install.
